### PR TITLE
chore: add org-wide `CONTRIBUTING.md` and generic issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,89 @@
+name: Bug Report
+description: Create a bug report
+labels: ["C-bug", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please provide as much detail as possible.
+
+        If you believe you have found a vulnerability, please provide details [here](mailto:security@tempo.xyz) instead.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+
+        If the bug is in a crate or package you are using please mention that as well.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please provide any steps you think might be relevant to reproduce the bug.
+      placeholder: |
+        Steps to reproduce:
+
+        1. Start '...'
+        2. Then '...'
+        3. Check '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        If applicable, please provide the logs leading up to the bug.
+      render: text
+    validations:
+      required: false
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform(s)
+      description: What platform(s) did this occur on?
+      multiple: true
+      options:
+        - Linux (x86)
+        - Linux (ARM)
+        - Mac (Intel)
+        - Mac (Apple Silicon)
+        - Windows (x86)
+        - Windows (ARM)
+  - type: dropdown
+    id: container_type
+    attributes:
+      label: Container Type
+      description: Were you running it in a container?
+      multiple: true
+      options:
+        - Not running in a container
+        - Docker
+        - Kubernetes
+        - LXC/LXD
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: client-version
+    attributes:
+      label: What version/commit are you on?
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: If you've built from source, provide the full command you used
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/tempoxyz/.github/blob/main/CONTRIBUTING.md#code-of-conduct)
+      options:
+        - label: I agree to follow the Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,15 @@
+name: Documentation
+description: Suggest a change to our documentation
+labels: ["C-docs", "S-needs-triage"]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the change
+      description: |
+        Please describe the documentation you want to change or add, and if it is for end-users or contributors.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources).

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest a feature
+labels: ["C-enhancement", "S-needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please ensure that the feature has not already been requested in the issue tracker.
+  - type: textarea
+    attributes:
+      label: Describe the feature
+      description: |
+        Please describe the feature and what it is aiming to solve, if relevant.
+
+        If the feature is for a crate or package, please include a proposed API surface.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context to the feature (like screenshots, resources).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,198 @@
+## Contributing to Tempo
+
+Thanks for your interest in improving Tempo!
+
+There are multiple opportunities to contribute at any level. It doesn't matter if you are just getting started with Rust
+or if you are already the most weathered expert, we can use your help.
+
+**No contribution is too small and all contributions are valued.**
+
+This document will help you get started. **Do not let the document intimidate you**.
+It should be considered as a guide to help you navigate the process.
+
+If you contribute to this project, your contributions will be made to the project under both Apache 2.0 and the MIT
+license.
+
+### Code of Conduct
+
+Tempo adheres to the [Rust Code of Conduct][rust-coc]. This code of conduct describes the _minimum_ behavior
+expected from all contributors.
+
+Instances of violations of the Code of Conduct can be reported by contacting the team
+at [georgios@tempo.xyz](mailto:georgios@tempo.xyz).
+
+### Ways to contribute
+
+There are fundamentally three ways an individual can contribute:
+
+1. **By opening an issue:** For example, if you believe that you have uncovered a bug
+   in Tempo, creating a new issue in the issue tracker is the way to report it.
+2. **By adding context:** Providing additional context to existing issues,
+   such as screenshots and code snippets to help resolve issues.
+3. **By resolving issues:** Typically this is done in the form of either
+   demonstrating that the issue reported is not a problem after all, or more often,
+   by opening a pull request that fixes the underlying problem, in a concrete and
+   reviewable manner.
+
+**Anybody can participate in any stage of contribution**. We urge you to participate in the discussion around bugs and
+participate in reviewing PRs.
+
+### Contributions Related to Spelling and Grammar
+
+At this time, we will not be accepting contributions that only fix spelling or grammatical errors in documentation, code or
+elsewhere.
+
+### Submitting a bug report
+
+When filing a new bug report in the issue tracker, you will be presented with a basic form to fill out.
+
+If you believe that you have uncovered a bug, please fill out the form to the best of your ability. Do not worry if you
+cannot answer every detail, just fill in what you can. Contributors will ask follow-up questions if something is
+unclear.
+
+The most important pieces of information we need in a bug report are:
+
+- The version you are on (and that it is up to date)
+- The platform you are on (Windows, macOS, an M1 Mac or Linux)
+- Code snippets if this is happening in relation to testing or building code
+- Concrete steps to reproduce the bug
+
+In order to rule out the possibility of the bug being in your project, the code snippets should be as minimal as
+possible. It is better if you can reproduce the bug with a small snippet as opposed to an entire project!
+
+See [this guide][mcve] on how to create a minimal, complete, and verifiable example.
+
+### Submitting a feature request
+
+When adding a feature request in the issue tracker, you will be presented with a basic form to fill out.
+
+Please include as detailed of an explanation as possible of the feature you would like, adding additional context if
+necessary.
+
+If you have examples of other tools that have the feature you are requesting, please include them as well.
+
+### Resolving an issue
+
+Pull requests are the way concrete changes are made to the code, documentation, and dependencies of Tempo.
+
+Even tiny pull requests, like fixing wording, are greatly appreciated. Before making a large change, it is usually a
+good idea to first open an issue describing the change to solicit feedback and guidance. This will increase the
+likelihood of the PR getting merged.
+
+If you are working on a larger feature, we encourage you to open up a draft pull request, to make sure that other
+contributors are not duplicating work.
+
+#### Adding tests
+
+If the change being proposed alters code, it is either adding new functionality to Tempo, or fixing existing, broken
+functionality.
+In both of these cases, the pull request should include one or more tests to ensure that Tempo does not regress in the
+future.
+
+Types of tests include:
+
+- **Unit tests**: Functions which have very specific tasks should be unit tested.
+- **Integration tests**: For general purpose, far reaching functionality,
+  integration tests should be added. The best way to add a new integration test is to look at existing ones and follow
+  the style.
+
+#### Commits
+
+It is a recommended best practice to keep your changes as logically grouped as possible within individual commits. There
+is no limit to the number of commits any single pull request may have, and many contributors find it easier to review
+changes that are split across multiple commits.
+
+That said, if you have a number of commits that are "checkpoints" and don't represent a single logical change, please
+squash those together.
+
+#### Opening the pull request
+
+From within GitHub, opening a new pull request will present you with a template that should be filled out. Please try
+your best at filling out the details, but feel free to skip parts if you're not sure what to put.
+
+#### Discuss and update
+
+You will probably get feedback or requests for changes to your pull request.
+This is a big part of the submission process, so don't be discouraged! Some contributors may sign off on the pull
+request right away, others may have more detailed comments or feedback. This is a necessary part of the process in order
+to evaluate whether the changes are correct and necessary.
+
+**Any community member can review a PR, so you might get conflicting feedback**. Keep an eye out for comments from code
+owners to provide guidance on conflicting feedback.
+
+#### Reviewing pull requests
+
+**Any Tempo community member is welcome to review any pull request**.
+
+All contributors who choose to review and provide feedback on pull requests have a responsibility to both the project
+and individual making the contribution. Reviews and feedback must be helpful, insightful, and geared towards improving
+the contribution as opposed to simply blocking it. If there are reasons why you feel the PR should not be merged,
+explain what those are. Do not expect to be able to block a PR from advancing simply because you say "no" without giving
+an explanation. Be open to having your mind changed. Be open to working _with_ the contributor to make the pull request
+better.
+
+Reviews that are dismissive or disrespectful of the contributor or any other reviewers are strictly counter to
+the [Code of Conduct][coc-header].
+
+When reviewing a pull request, the primary goals are for the codebase to improve and for the person submitting the
+request to succeed. **Even if a pull request is not merged, the submitter should come away from the experience feeling
+like their effort was not unappreciated**. Every PR from a new contributor is an opportunity to grow the community.
+
+##### Review a bit at a time
+
+Do not overwhelm new contributors.
+
+It is tempting to micro-optimize and make everything about relative performance, perfect grammar, or exact style
+matches. Do not succumb to that temptation.
+
+Focus first on the most significant aspects of the change:
+
+1. Does this change make sense for Tempo?
+2. Does this change make Tempo better, even if only incrementally?
+3. Are there clear bugs or larger scale issues that need attending?
+4. Are the commit messages readable and correct? If it contains a breaking change, is it clear enough?
+
+Note that only **incremental** improvement is needed to land a PR. This means that the PR does not need to be perfect,
+only better than the status quo. Follow-up PRs may be opened to continue iterating.
+
+When changes are necessary, _request_ them, do not _demand_ them, and **do not assume that the submitter already knows
+how to add a test or run a benchmark**.
+
+Specific performance optimization techniques, coding styles and conventions change over time. The first impression you
+give to a new contributor never does.
+
+Nits (requests for small changes that are not essential) are fine, but try to avoid stalling the pull request. Most nits
+can typically be fixed by the Tempo maintainers merging the pull request, but they can also be an opportunity for the
+contributor to learn a bit more about the project.
+
+It is always good to clearly indicate nits when you comment,
+e.g.: `Nit: change foo() to bar(). But this is not blocking`.
+
+If your comments were addressed but were not folded after new commits, or if they proved to be mistaken,
+please, [hide them][hiding-a-comment] with the appropriate reason to keep the conversation flow concise and relevant.
+
+##### Be aware of the person behind the code
+
+Be aware that _how_ you communicate requests and reviews in your feedback can have a significant impact on the success
+of the pull request. Yes, we may merge a particular change that makes Tempo better, but the individual might just not
+want to have anything to do with Tempo ever again. The goal is not just having good code.
+
+##### Abandoned or stale pull requests
+
+If a pull request appears to be abandoned or stalled, it is polite to first check with the contributor to see if they
+intend to continue the work before checking if they would mind if you took it over (especially if it just has nits
+left). When doing so, it is courteous to give the original contributor credit for the work they started, either by
+preserving their name and e-mail address in the commit log, or by using the `Author: ` or `Co-authored-by: ` metadata
+tag in the commits.
+
+_Adapted from the [Reth contributing guide][reth-contributing]_.
+
+[rust-coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
+
+[coc-header]: #code-of-conduct
+
+[mcve]: https://stackoverflow.com/help/mcve
+
+[hiding-a-comment]: https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment
+
+[reth-contributing]: https://github.com/paradigmxyz/reth/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
Local repo's can always override the org-wide `CONTRIBUTING.md` and issue templates if needed